### PR TITLE
Bump text upper version bounds

### DIFF
--- a/quickcheck-instances.cabal
+++ b/quickcheck-instances.cabal
@@ -44,7 +44,7 @@ Library
                        unordered-containers >= 0.2.1 && < 0.3,
                        old-time >= 1.0 && < 1.2,
                        QuickCheck >= 2.1 && < 2.8,
-                       text >= 0.7 && < 1.2,
+                       text >= 0.7 && < 1.3,
                        time >= 1.1 && < 1.5
 
   Ghc-options:         -Wall


### PR DESCRIPTION
Allow `quickcheck-instances` to use `text-1.2.0.0`.
