### PR TITLE
Fix build with GHC 8.0.1, QuickCheck-2.8.2

### DIFF
--- a/quickcheck-instances.cabal
+++ b/quickcheck-instances.cabal
@@ -34,7 +34,7 @@ Source-repository head
 Library
   -- Modules exported by the library.
   Exposed-modules:     Test.QuickCheck.Instances
-  Hs-Source-Dirs:      src  
+  Hs-Source-Dirs:      src
   Build-depends:       base < 5,
 
                        array >= 0.3 && < 0.6,
@@ -45,11 +45,11 @@ Library
                        old-time >= 1.0 && < 1.2,
                        QuickCheck >= 2.1 && < 2.9,
                        text >= 0.7 && < 1.3,
-                       time >= 1.1 && < 1.6,
+                       time >= 1.1 && < 1.7,
                        vector >= 0.9 && <0.12,
                        scientific >=0.2 && <0.4
 
   Ghc-options:         -Wall
   Other-modules:       Test.QuickCheck.Instances.LegacyNumeric
-  -- Build-tools:         
-  
+  -- Build-tools:
+

--- a/src/Test/QuickCheck/Instances.hs
+++ b/src/Test/QuickCheck/Instances.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-| 
+{-|
 Instances are provided for the types in the packages:
 
  * array
@@ -180,6 +180,7 @@ instance Function TL.Text where
     function = functionMap TL.unpack TL.pack
 
 -- Containers
+#if !(MIN_VERSION_QuickCheck(2,8,2))
 instance Arbitrary a => Arbitrary (IntMap.IntMap a) where
     arbitrary = IntMap.fromList <$> arbitrary
     shrink m = IntMap.fromList <$> shrink (IntMap.toList m)
@@ -217,6 +218,7 @@ instance CoArbitrary a => CoArbitrary (Set.Set a) where
 
 instance (Ord a, Function a) => Function (Set.Set a) where
     function = functionMap Set.toList Set.fromList
+#endif
 
 instance (Hashable a, Eq a, Arbitrary a) => Arbitrary (HS.HashSet a) where
     arbitrary = HS.fromList <$> arbitrary
@@ -236,7 +238,7 @@ instance Arbitrary a => Arbitrary (Tree.Tree a) where
     arbitrary = sized $ \n ->
       do val <- arbitrary
          let n' = n `div` 2
-         nodes <- 
+         nodes <-
              if n' > 0
               then do
                 k <- choose (0,n')


### PR DESCRIPTION
`QuickCheck-2.8.2` defines some instances currently present in `quickcheck-instances`, so I CPP'ed them out. I also upper version-bumped `time` to `< 1.7` to allow it to build with GHC 8.0.1.

Fixes #18.